### PR TITLE
Switched hashing over to Blake2 for better performance

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2018"
 
 [dependencies]
 clap = "~2.33.0"
-sha2 = "~0.8.0"
+blake2 = "0.8"
 
 [[bin]]
 name = "dupcheck"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -260,7 +260,7 @@ impl DupResults {
                 // this file is only checked if its path hasn't been added in a
                 // previous check.
                 if !self.contains(file) {
-                    let hash = match file.sha256() {
+                    let hash = match file.blake2() {
                         Ok(h) => h,
                         Err(e) => {
                             self.errors.push(io::Error::new(
@@ -348,7 +348,7 @@ impl DupResults {
 /// A group of duplicate files.
 #[derive(Debug)]
 pub struct DupGroup {
-    /// The SHA-256 hash of the files in this group.
+    /// The Blake2 hash of the files in this group.
     hash: String,
 
     /// The paths to the duplicate files.
@@ -356,7 +356,7 @@ pub struct DupGroup {
 }
 
 impl DupGroup {
-    /// Returns the SHA-256 hash of the files in this group.
+    /// Returns the Blake2 hash of the files in this group.
     pub fn get_hash(&self) -> String {
         self.hash.clone()
     }

--- a/src/utilities.rs
+++ b/src/utilities.rs
@@ -1,21 +1,21 @@
-use sha2::{Digest, Sha256};
+use blake2::{Blake2b, Digest};
 use std::error::Error;
 use std::fs;
 use std::io;
 use std::path::PathBuf;
 
 pub(crate) trait PathUtilities {
-    /// Returns a file's SHA-256 hash.
-    fn sha256(&self) -> io::Result<String>;
+    /// Returns a file's Blake2 hash.
+    fn blake2(&self) -> io::Result<String>;
 
     /// Returns all files within a directory, optionally of certain `sizes`.
     fn files_within(&self, sizes: Option<&[u64]>) -> io::Result<Vec<PathBuf>>;
 }
 
 impl PathUtilities for PathBuf {
-    fn sha256(&self) -> io::Result<String> {
+    fn blake2(&self) -> io::Result<String> {
         let bytes = fs::read(self.as_path())?;
-        let mut hasher = Sha256::new();
+        let mut hasher = Blake2b::new();
         hasher.input(&bytes);
 
         Ok(format!("{:x}", hasher.result()))


### PR DESCRIPTION
Was able to get some performance gains by using Blake2 over a large amount of files. Tested on FreeBSD 12.1 x64-64 and ZFS. 